### PR TITLE
Add name of config file to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ You only need to add the last line to your config file.
 
 ### Configure the middleware
 
-The config file by default is `$HOME/.ehforwarderbot/profiles/default/catbaron.mp_instanceview`.
+The config file by default is `$HOME/.ehforwarderbot/profiles/default/catbaron.mp_instanceview/config.yaml`.
 Please create the config file if thers is not one. You need to have a telegraph token and save it here. You can get a token following [the document](https://telegra.ph/api#createAccount). The `access_token` is what you need.
 
 ```yaml


### PR DESCRIPTION
Adding the name of the config file to README as some users may mistaken the path name for the file name [[Ref.][r0]].

[r0]: https://t.me/c/1083959736/72876