### PR TITLE
Raise error and stop init process when config file is not loaded successfully

### DIFF
--- a/efb_mp_instanceview_middleware/__init__.py
+++ b/efb_mp_instanceview_middleware/__init__.py
@@ -34,13 +34,11 @@ class MPInstanceViewMiddleware(Middleware):
     def load_config(self) -> Optional[Dict]:
         config_path: Path = get_config_path(self.middleware_id)
         if not config_path.exists():
-            self.logger.info('The configure file does not exist!')
-            return
+            raise FileNotFoundError('The configure file does not exist!')
         with config_path.open('r') as f:
             d: Dict[str, Any] = yaml.load(f)
             if not d:
-                self.logger.info('Load configure file failed!')
-                return
+                raise RuntimeError('Load configure file failed!')
             return d
 
     @staticmethod


### PR DESCRIPTION
The current `logger.info` method is resulting error messages not being seen by the user unless in verbose mode.

It is recommended to throw exceptions and stop the initialization process when there is error in loading config from disk, as failing to load config file would render the middleware useless.

Alternatively, you may also want to silently suppress the config errors and replace functions with no-ops as if this middleware doesn’t exist.